### PR TITLE
fix import error in systerm-receipt-printer.cjs

### DIFF
--- a/dist/system-receipt-printer.cjs
+++ b/dist/system-receipt-printer.cjs
@@ -36,7 +36,7 @@ class SystemReceiptPrinter extends ReceiptPrinterDriver {
 		this.#emitter = new EventEmitter();
 
         this.#options = {
-			name:		options.name || '',
+			name:		options?.name || '',
         };
 	}
 


### PR DESCRIPTION
node_modules\@point-of-sale\system-receipt-printer\dist\system-receipt-printer.cjs:39
                        name:           options.name || '',
                                                ^

TypeError: Cannot read properties of undefined (reading 'name')
    at new SystemReceiptPrinter (D:\prototype\PM alternavite for USB\node_modules\@point-of-sale\system-receipt-printer\dist\system-receipt-printer.cjs:39:19)
    at Object.<anonymous> (D:\prototype\PM alternavite for USB\testUSB.js:3:22)
    at Module._compile (node:internal/modules/cjs/loader:1364:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1422:10)
    at Module.load (node:internal/modules/cjs/loader:1203:32)
    at Module._load (node:internal/modules/cjs/loader:1019:12)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:128:12)
    at node:internal/main/run_main_module:28:49

Node.js v18.20.4